### PR TITLE
fixing typedoc so it will build documentation when outside the pwd

### DIFF
--- a/assets/sample/README.md
+++ b/assets/sample/README.md
@@ -1,0 +1,3 @@
+# Title
+
+This is a README!

--- a/assets/sample/index.ts
+++ b/assets/sample/index.ts
@@ -1,0 +1,3 @@
+export default function (name: string): void {
+	console.log(`hello ${ name }`);
+}

--- a/assets/sample/tsconfig.json
+++ b/assets/sample/tsconfig.json
@@ -26,8 +26,6 @@
 		"target": "ES5"
 	},
 	"include": [
-		"./src/**/*.ts",
-		"./tasks/**/*.ts",
-		"./tests/**/*.ts"
+		"*.ts"
 	]
 }

--- a/support/grunt/config.ts
+++ b/support/grunt/config.ts
@@ -2,9 +2,11 @@ import { repositorySource } from '../../src/util/environment';
 
 export const apiDirectory = '_apidocs';
 
-export const cloneDirectory = '.repo';
+export const cloneDirectory = '.sync';
 
 export const distDirectory = '_build';
+
+export const testTempDirectory = '.test';
 
 export const [ repoOwner, repoName ] = repositorySource().split('/');
 
@@ -13,7 +15,6 @@ export const api = {
 		format: 'html',
 		typedoc: {
 			mode: 'file',
-			externalPattern: '"**/+(example|examples|node_modules|tests|typings)/**/*.ts"',
 			excludeExternals: true,
 			excludeNotExported: true,
 			ignoreCompilerErrors: true
@@ -22,14 +23,14 @@ export const api = {
 	html: {
 		options: {
 			dest: '<%= apiDirectory %>',
-			src: 'src'
+			src: '.'
 		}
 	},
 	json: {
 		options: {
 			format: 'json',
 			dest: '<%= apiDirectory %>/api.json',
-			src: 'src'
+			src: '.'
 		}
 	}
 };
@@ -37,7 +38,8 @@ export const api = {
 export const clean = {
 	build: [ '<%= distDirectory %>' ],
 	dists: [ '<%= cloneDirectory %>' ],
-	repo: [ '<%= cloneDirectory %>/**/*', '!.git/**' ]
+	repo: [ '<%= cloneDirectory %>/**/*', '!.git/**' ],
+	tests: [ '<%= testTempDirectory %>' ]
 };
 
 export const copy = {
@@ -71,13 +73,20 @@ export const initAutomation = {
 };
 
 export const intern = {
+	options: {
+		runType: 'client',
+		reporters: [
+			'Console', 'LcovHtml'
+		]
+	},
 	unit: {
 		options: {
-			runType: 'client',
-			config: '_build/tests/intern',
-			reporters: [
-				'Console', 'LcovHtml'
-			]
+			config: '_build/tests/intern'
+		}
+	},
+	integration: {
+		options: {
+			config: '_build/tests/intern-integration'
 		}
 	}
 };

--- a/support/grunt/index.ts
+++ b/support/grunt/index.ts
@@ -1,8 +1,10 @@
 import * as config from './config';
 import { join, basename, extname } from 'path';
 import { readdirSync } from 'fs';
+import { logger } from '../../src/log';
 
 export = function (grunt: IGrunt) {
+	logger.level = 'debug';
 	require('load-grunt-tasks')(grunt);
 	grunt.loadNpmTasks('intern');
 
@@ -19,6 +21,8 @@ export = function (grunt: IGrunt) {
 	grunt.registerTask('build', [ 'shell:build-ts', 'copy:staticDistFiles' ]);
 	grunt.registerTask('dev', [ 'clean', 'tslint', 'build' ]);
 	grunt.registerTask('test', [ 'dev', 'intern' ]);
+	grunt.registerTask('unit', [ 'dev', 'intern:unit' ]);
+	grunt.registerTask('integration', [ 'dev', 'intern:integration' ]);
 	grunt.registerTask('init', [ 'prompt:github', 'initAutomation' ]);
 	grunt.registerTask('cd-latest', [ 'prebuild', 'sync:latest', 'clean:repo', 'copy:latest', 'publish:latest' ]);
 	grunt.registerTask('cd-api', [ 'prebuild', 'sync:gh-pages', 'clean:repo', 'api', 'copy:gh-pages', 'publish:gh-pages' ]);

--- a/tasks/api.ts
+++ b/tasks/api.ts
@@ -1,10 +1,5 @@
 import IMultiTask = grunt.task.IMultiTask;
-import typedoc, {
-	BaseOptions as TypedocBaseOptions,
-	HtmlOptions as TypedocHtmlOptions,
-	JsonOptions as TypedocJsonOptions,
-	Options as TypedocOptions
-} from '../src/commands/typedoc';
+import typedoc, { Options as TypedocOptions } from '../src/commands/typedoc';
 import wrapAsyncTask from './util/wrapAsyncTask';
 import GitHub, { Release } from '../src/util/GitHub';
 import sync from '../src/commands/sync';
@@ -17,7 +12,7 @@ import getReleases, {
 	latestFilter,
 	ReleaseFilter
 } from '../src/commands/getReleases';
-import { join } from 'path';
+import { join, resolve } from 'path';
 import { mkdtempSync } from 'fs';
 import installDependencies from '../src/commands/installDependencies';
 import { logger } from '../src/log';
@@ -89,19 +84,6 @@ function createTempDirectory(name: string = ''): string {
 	return mkdtempSync(join('.sync', name));
 }
 
-function createTypedocOptions(options: TaskOptions, target: string, source: string): TypedocOptions {
-	const typedocOptions: TypedocBaseOptions = (<any> Object).assign({}, options.typedoc, {
-		source
-	});
-	if (options.format === 'json') {
-		(<TypedocJsonOptions> typedocOptions).json = target;
-	}
-	else {
-		(<TypedocHtmlOptions> typedocOptions).out = target;
-	}
-	return <TypedocOptions> typedocOptions;
-}
-
 export = function (grunt: IGrunt) {
 	async function typedocTask(this: IMultiTask<any>) {
 		const options: any = this.options<Partial<TaskOptions>>({
@@ -145,14 +127,14 @@ export = function (grunt: IGrunt) {
 				if (options.skipInstall !== true) {
 					await installDependencies(cloneDirectory);
 				}
-				await typedoc(createTypedocOptions(options, target, cloneDirectory));
+				await typedoc(cloneDirectory, target, options.typedoc);
 			}
 		}
 		else {
 			if (options.skipInstall === false) {
 				await installDependencies(src);
 			}
-			await typedoc(createTypedocOptions(options, dest, src));
+			await typedoc(resolve(src), dest, options.typedoc);
 		}
 	}
 

--- a/tests/integration/all.ts
+++ b/tests/integration/all.ts
@@ -1,0 +1,1 @@
+import './typedoc';

--- a/tests/integration/typedoc.ts
+++ b/tests/integration/typedoc.ts
@@ -1,0 +1,18 @@
+import * as registerSuite from 'intern!object';
+import * as assert from 'intern/chai!assert';
+import typedoc from 'src/commands/typedoc';
+import { tmpDirectory } from '../_support/tmpFiles';
+import { readFileSync } from 'fs';
+import { join } from 'path';
+
+registerSuite({
+	name: 'typedoc',
+
+	async build() {
+		const out = tmpDirectory();
+
+		await typedoc((<any> require).toUrl('assets/sample'), out);
+		const indexFile = readFileSync(join(out, 'index.html'));
+		assert.include(String(indexFile), 'This is a README!');
+	}
+});

--- a/tests/intern-integration.ts
+++ b/tests/intern-integration.ts
@@ -1,0 +1,3 @@
+export * from './intern';
+
+export const suites = [ 'tests/integration/all' ];

--- a/tests/intern.ts
+++ b/tests/intern.ts
@@ -2,6 +2,7 @@ import 'intern';
 
 export const loaderOptions = {
 	packages: [
+		{ name: 'assets', location: 'assets' },
 		{ name: 'tslib', location: './node_modules/tslib', main: 'tslib.js' },
 		{ name: 'tasks', location: './_build/tasks' },
 		{ name: 'src', location: './_build/src' },


### PR DESCRIPTION
Works around an issue where Typedoc doesn't look for a tsconfig file in the provided source directory when using the CLI. I provided a write-up here: TypeStrong/typedoc#244

This resolves the issue by explicitly providing a tsconfig to use based on the source directory